### PR TITLE
CHANGE: Use only string-type parameter in fsl templates

### DIFF
--- a/femagtools/templates/basic_modpar.mako
+++ b/femagtools/templates/basic_modpar.mako
@@ -1,6 +1,6 @@
-  global_unit(mm)
+  global_unit("mm")
   pickdist(0.001)
-  cosys(polar)
+  cosys("polar")
 
 <%include file="fe-contr.mako" />
 

--- a/femagtools/templates/gen_winding.mako
+++ b/femagtools/templates/gen_winding.mako
@@ -20,14 +20,14 @@ m.curr_inp        =   0.0 -- const
 m.dq_offset       =   0
 
 % if model.get(['stator', 'num_slots_gen']) == 1:
-def_new_wdg(m.xcoil_1, m.ycoil_1, green, "1", m.num_wires, 0.0, wi)
-add_to_wdg(m.xcoil_2, m.ycoil_2, wsamekey, wo, wser) 
+def_new_wdg(m.xcoil_1, m.ycoil_1, "green", "1", m.num_wires, 0.0, "wi")
+add_to_wdg(m.xcoil_2, m.ycoil_2, "wsamekey", "wo", "wser")
 % else:
 pre_models("Gen_winding")
 pre_models("gen_pocfile") 
 % endif
 % else:
-color={green, yellow, magenta,lightgrey,darkred,skyblue,violet}
+color={"green", "yellow", "magenta", "lightgrey", "darkred", "skyblue", "violet"}
 wkey={0,0,0,0,0,0}
 --
 bz = m.width_bz
@@ -42,19 +42,19 @@ for i=1, m.num_phases do
     if g == 1 then
       wkey[i]=def_new_wdg(xs + bz/3, ys, color[i], wdg, m.num_wires, 0, dirl)
     else
-      add_to_wdg(xs + bz/3, ys, color[i], wkey[i], dirl, wser )
+      add_to_wdg(xs + bz/3, ys, color[i], wkey[i], dirl, "wser")
     end
     if m.num_layers > 1 then
-      add_to_wdg(xs + bz - bz/3, ys, wkey[i], dirl, wser)
+      add_to_wdg(xs + bz - bz/3, ys, wkey[i], dirl, "wser")
     end
     dirl = -dirl
     if i > 1 or g > 1 then
-      add_to_wdg(xs - bz/3, ys, wkey[i], dirl, wser)
+      add_to_wdg(xs - bz/3, ys, wkey[i], dirl, "wser")
     else
-      add_to_wdg(m.num_sl_gen*bz - bz/3, ys, wkey[i], -dirl, wser)
+      add_to_wdg(m.num_sl_gen*bz - bz/3, ys, wkey[i], -dirl, "wser")
     end
     if m.num_layers > 1 then
-      add_to_wdg(xs + bz + bz/3, ys, wkey[i], dirl, wser)
+      add_to_wdg(xs + bz + bz/3, ys, wkey[i], dirl, "wser")
     end
   end
 end

--- a/femagtools/templates/magnetIron.mako
+++ b/femagtools/templates/magnetIron.mako
@@ -29,13 +29,13 @@ for i = 0, m.npols_gen-1 do
     if i < 2 and m.npols_gen > 1 then
         delete_sreg(x0, y0)
     end
-    if m.orient == mcartaniso or m.orient == mcartiso then
+    if m.orient == "cartaniso" or m.orient == "cartiso" then
         gamma = alfa
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
     end
 end
 %endif

--- a/femagtools/templates/magnetIron2.mako
+++ b/femagtools/templates/magnetIron2.mako
@@ -31,13 +31,13 @@ for i = 0, m.npols_gen-1 do
     if i < 2 and m.npols_gen > 1 then
         delete_sreg(x0, y0)
     end    
-    if m.orient == mcartaniso or m.orient == mcartiso then
+    if m.orient == "cartaniso" or m.orient == "cartiso" then
         gamma = alfa
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
     end
 end
 %endif

--- a/femagtools/templates/magnetIron3.mako
+++ b/femagtools/templates/magnetIron3.mako
@@ -36,9 +36,9 @@ for i = 0, m.npols_gen-1 do
         alfa = (2*i+1)*gamma*180/math.pi
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, alfa, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, alfa, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, alfa-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, alfa-180, m.orient, m.magncond, m.rlen)
     end
 end
 else
@@ -51,15 +51,15 @@ for i = 0, m.npols_gen-1 do
         delete_sreg(x0, y0)
 	delete_sreg(x1, y1)
     end
-    if m.orient == mpolaniso or m.orient == mpoliso then
+    if m.orient == "polaniso" or m.orient == "poliso" then
         alfa = 0
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, (alfa+gamma/2)*180/math.pi, m.orient, m.magncond, m.rlen)
-        def_mat_pm_nlin(x1, y1, red, m.mcvkey_magnet, (alfa-gamma/2)*180/math.pi, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, (alfa+gamma/2)*180/math.pi, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x1, y1, "red", m.mcvkey_magnet, (alfa-gamma/2)*180/math.pi, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, (alfa+gamma/2)*180/math.pi-180, m.orient, m.magncond, m.rlen)
-        def_mat_pm_nlin(x1, y1, green, m.mcvkey_magnet, (alfa-gamma/2)*180/math.pi-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, (alfa+gamma/2)*180/math.pi-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x1, y1, "green", m.mcvkey_magnet, (alfa-gamma/2)*180/math.pi-180, m.orient, m.magncond, m.rlen)
     end
 end
 end

--- a/femagtools/templates/magnetIron4.mako
+++ b/femagtools/templates/magnetIron4.mako
@@ -30,13 +30,13 @@ for i = 0, m.npols_gen-1 do
     if i < 2 and m.npols_gen > 1 then
         delete_sreg(x0, y0)
     end
-    if m.orient == mcartaniso or m.orient == mcartiso then
+    if m.orient == "cartaniso" or m.orient == "cartiso" then
         gamma = alfa
     end    
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
     end
 end
 %endif

--- a/femagtools/templates/magnetIron5.mako
+++ b/femagtools/templates/magnetIron5.mako
@@ -34,9 +34,9 @@ for i = 0, m.npols_gen-1 do
         gamma = alfa
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
     end
 end
 %endif

--- a/femagtools/templates/magnetIronV.mako
+++ b/femagtools/templates/magnetIronV.mako
@@ -44,26 +44,26 @@ delta = 0
 for i = 0, m.npols_gen-1 do
     gamma = (2*i+1)*180/m.num_poles
     x0, y0 = pd2c(d, gamma-alpha/math.pi*180)
-    if m.orient == mcartaniso or m.orient == mcartiso then
+    if m.orient == "cartaniso" or m.orient == "cartiso" then
         delta = gamma-m.magn_angle/2+90
     else
         delta = m.magn_angle/2 - 90/m.num_poles
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, delta, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, delta, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, delta-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, delta-180, m.orient, m.magncond, m.rlen)
     end
     x0, y0 = pd2c(d, gamma+alpha/math.pi*180)
-    if m.orient == mcartaniso or m.orient == mcartiso then
+    if m.orient == "cartaniso" or m.orient == "cartiso" then
        delta = gamma+m.magn_angle/2-90
     else
         delta = -m.magn_angle/2 + 90/m.num_poles
     end
     if i % 2 == 0 then
-        def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, delta, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, delta, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, delta+180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, delta+180, m.orient, m.magncond, m.rlen)
     end
 end
 %endif

--- a/femagtools/templates/magnetSector.mako
+++ b/femagtools/templates/magnetSector.mako
@@ -41,11 +41,11 @@ for i = 0, m.npols_gen-1 do
     alfa = (2*i+1)*180/m.num_poles
     x0, y0 = pd2c(m.magn_rad - m.magn_height/2, alfa)
     if i % 2 == 0 then
-      color = red
+      color = "red"
       phi = alfa+180/m.num_poles
     else
       phi = -90
-      color = green
+      color = "green"
     end
     def_mat_pm(x0, y0, color, m.remanenc, m.relperm,
 	               phi, m.radial, m.magncond, m.rlen)
@@ -58,13 +58,13 @@ for i = 0, m.npols_gen-1 do
     if i < 2 and m.npols_gen > 1 then
         delete_sreg(x0, y0)
     end
-    if m.orient == mcartaniso or m.orient == mcartiso then
+    if m.orient == "cartaniso" or m.orient == "cartiso" then
         gamma = alfa
     end
     if i % 2 == 0 then
-	  def_mat_pm_nlin(x0, y0, red, m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
+	  def_mat_pm_nlin(x0, y0, "red", m.mcvkey_magnet, gamma, m.orient, m.magncond, m.rlen)
     else
-        def_mat_pm_nlin(x0, y0, green, m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
+        def_mat_pm_nlin(x0, y0, "green", m.mcvkey_magnet, gamma-180, m.orient, m.magncond, m.rlen)
     end
 end
 %endif

--- a/femagtools/templates/stator1.mako
+++ b/femagtools/templates/stator1.mako
@@ -18,5 +18,5 @@ pre_models( "STATOR_1")
 
 if mcvkey_teeth ~= nil then
   x0, y0 = pr2c( (m.tip_rh1 + m.slot_rf1)/2, 2*math.pi/m.tot_num_slot + m.zeroangl/180*math.pi)
-   def_mat_fm_nlin(x0, y0, blue, mcvkey_teeth, m.rlength)
+   def_mat_fm_nlin(x0, y0, "blue", mcvkey_teeth, m.rlength)
 end

--- a/femagtools/templates/stator4.mako
+++ b/femagtools/templates/stator4.mako
@@ -27,5 +27,5 @@ if mcvkey_teeth ~= nil then
      r = (da1 - m.slot_height)/2
   end  
   x0, y0 = pr2c(r, 2*math.pi/m.tot_num_slot + m.zeroangl/180*math.pi)
-   def_mat_fm_nlin(x0, y0, blue, mcvkey_teeth, m.rlength)
+   def_mat_fm_nlin(x0, y0, "blue", mcvkey_teeth, m.rlength)
 end

--- a/femagtools/templates/statorBG.mako
+++ b/femagtools/templates/statorBG.mako
@@ -24,5 +24,5 @@ m.mcvkey_yoke = mcvkey_yoke
 if mcvkey_teeth ~= nil then
   r = (da1 + m.yoke_diam_ins)/4
   x0, y0 = pr2c(r, 2*math.pi/m.tot_num_slot + m.zeroangl/180*math.pi)
-   def_mat_fm_nlin(x0, y0, blue, mcvkey_teeth, m.rlength)
+   def_mat_fm_nlin(x0, y0, "blue", mcvkey_teeth, m.rlength)
 end

--- a/femagtools/templates/statorRotor3.mako
+++ b/femagtools/templates/statorRotor3.mako
@@ -32,5 +32,5 @@ if mcvkey_teeth ~= nil then
      r = (m.inside_diam - m.slot_height)/2
   end  
   x0, y0 = pr2c(r, 2*math.pi/m.tot_num_slot + m.zeroangl/180*math.pi)
-   def_mat_fm_nlin(x0, y0, blue, mcvkey_teeth, m.rlength)
+   def_mat_fm_nlin(x0, y0, "blue", mcvkey_teeth, m.rlength)
 end

--- a/femagtools/templates/torq_calc.mako
+++ b/femagtools/templates/torq_calc.mako
@@ -32,7 +32,7 @@ m.fcpy_mm4        =   m.fcpy_mm3
 m.fcpx_mm5        =   m.fcpx_mm1
 m.fcpy_mm5        =   m.fcpy_mm1
 
-m.npols_gen       =  1 -- nuber of sectors simulated
+m.npols_gen       =  1 -- number of sectors simulated
 
 % endif
 m.nu_skew_steps   =    ${model.get('num_skew_steps',0)}


### PR DESCRIPTION
Looked through the mako-templates and tried to change all remaining, non-string-parameters  into their corresponding string representation.