### PR TITLE
small additions and fixes

### DIFF
--- a/femagtools/bch.py
+++ b/femagtools/bch.py
@@ -1403,6 +1403,8 @@ class Reader:
                     losses[k] = []
                 try:
                     rec = self.__findNums(l)
+                    if 'nan' in rec:
+                        continue
                     if len(rec) == 4:
                         losses[k].append([floatnan(x) for x in rec])
                     elif len(rec) == 5:  # FEMAG Rel 8.3 with el/mech order

--- a/femagtools/femag.py
+++ b/femagtools/femag.py
@@ -38,9 +38,17 @@ def get_shortCircuit_parameters(bch, nload):
         if nload < 0: nload=0
         if nload > 2: nload=2
         if nload > 0:
-            ld = bch.dqPar['ld'][nload-1]/bch.armatureLength
-            lq = bch.dqPar['lq'][nload-1]/bch.armatureLength
-            psim = bch.dqPar['psim'][nload-1]/bch.armatureLength
+            dqld = bch.dqPar['ld']
+            dqlq = bch.dqPar['lq']
+            dqpsim = bch.dqPar['psim']
+            if len(dqld) <= nload or len(dqlq) <= nload or len (dqpsim) <= nload:
+                ld = dqld[-1]/bch.armatureLength
+                lq = dqlq[-1]/bch.armatureLength
+                psim = dqpsim[-1]/bch.armatureLength
+            else:
+                ld = dqld[nload-1]/bch.armatureLength
+                lq = dqlq[nload-1]/bch.armatureLength
+                psim = dqpsim[nload-1]/bch.armatureLength
         else:
             ld = bch.machine['ld']/bch.armatureLength
             lq = bch.machine['lq']/bch.armatureLength

--- a/femagtools/fsl.py
+++ b/femagtools/fsl.py
@@ -24,8 +24,9 @@ class FslBuilderError(Exception):
 
 class Builder:
     def __init__(self):
-        if getattr(sys, 'frozen', False):
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
             # lookup up files in pyinstaller bundle
+            logging.debug("Frozen!")
             dirs = [os.path.join(sys._MEIPASS, 'fsltemplates'),
                     os.path.join(os.getcwd(), '.')]
         else:


### PR DESCRIPTION
Ordernumbers > 1000 are stored as `nan`, and led to errors, therefore skip them. Only a workaround at the moment, should be fixed in FEMAG. See also #56 

When freezing using [cxfreeze](https://pypi.org/project/cx-Freeze/), `sys._MEIPASS` is not created, so check for existance.

Short circuit parameters for calculation with 1 beta angle should already be implemented...

Loading a previous bch-file maybe only for special usecase, when reading the airgap flux density after doing a sc-simulation...


_Thank you and greeting from Germany!
Thomas_