### PR TITLE
FIX: using correct units for leak_evol_wind

### DIFF
--- a/femagtools/templates/leak_evol_wind.mako
+++ b/femagtools/templates/leak_evol_wind.mako
@@ -2,12 +2,12 @@
 m.nseg            = m.tot_num_slot/m.num_slots --   Number of segments                      
 m.npolsim         = m.npols_gen      --   Number of poles simulated             
 
-m.evol1rad        = ${model['evol1rad']} --  Top radius of first evolvent [mm]  
-m.evol2rad        = ${model['evol2rad']} --  Top radius of second evolvent [mm]   
-m.botlevel        = ${model['botlevel']} --  Level at bottom of evolvents [mm] 
-m.toplevel        = ${model['toplevel']} --  Level at top of evolvents [mm]   
-m.endheight       = ${model['endheight']} --  End winding height [mm]       
-m.evolbend        = ${model['evolbend']} --  Bending radius [mm] 
-m.wiredia         = ${model['wiredia']} --  Wire diameter [mm]                    
+m.evol1rad        = ${model['evol1rad']*1e3} --  Top radius of first evolvent [mm]
+m.evol2rad        = ${model['evol2rad']*1e3} --  Top radius of second evolvent [mm]
+m.botlevel        = ${model['botlevel']*1e3} --  Level at bottom of evolvents [mm]
+m.toplevel        = ${model['toplevel']*1e3} --  Level at top of evolvents [mm]
+m.endheight       = ${model['endheight']*1e3} --  End winding height [mm]
+m.evolbend        = ${model['evolbend']*1e3} --  Bending radius [mm]
+m.wiredia         = ${model['wiredia']*1e3} --  Wire diameter [mm]
 
  pre_models("leak_evol_wind")


### PR DESCRIPTION
FEMAG is expecting mm, femagtools are using m.
Only in template leak_evol_wind.mako. 
Other templates are OK!

