### PR TITLE
Airgap mesh creation with user defined fsl files for stator and rotor

### DIFF
--- a/femagtools/femag.py
+++ b/femagtools/femag.py
@@ -118,6 +118,8 @@ class BaseFemag(object):
 
         builder = femagtools.fsl.Builder()
         if simulation:
+            if "hc_min" in simulation:
+                self.model.__setattr__("hc_min", simulation.get("hc_min", 95))
             return builder.create(self.model, simulation, self.magnets)
         return builder.create_model(self.model, self.magnets) + ['save_model("cont")']
 
@@ -319,6 +321,8 @@ class Femag(BaseFemag):
                         get_shortCircuit_parameters(bch,
                                                     simulation.get('initial', 2)))
                     builder = femagtools.fsl.Builder()
+                    if "hc_min" in simulation:
+                        self.model.__setattr__("hc_min", simulation.get("hc_min", 95))
                     fslcmds = (builder.open_model(self.model) +
                                builder.create_shortcircuit(simulation))
                     with open(os.path.join(self.workdir, fslfile), 'w') as f:

--- a/femagtools/templates/mesh-airgap.mako
+++ b/femagtools/templates/mesh-airgap.mako
@@ -1,34 +1,43 @@
 
 
--- airgap
-ndt(agndst)
-r1 = m.fc_radius - ag/6
-x1, y1 = pr2c(r1, alfa)
-n = math.floor(r1*alfa/agndst + 1.5)
-nc_circle_m(r1, 0, x1, y1, 0.0, 0.0, n)
+-- airgap if not already created...
 
-r2 = m.fc_radius + ag/6
-x2, y2 = pr2c(r2, alfa)
-nc_circle_m(r2, 0, x2, y2, 0.0, 0.0, n)
+airgap_created = airgap_created or false
+if airgap_created ~= true then
+    if agndst == nil then
+      agndst = m.nodedist
+    end
+    ndt(agndst)
+    if alfa == nil then
+      alfa = m.npols_gen*2*math.pi/m.num_poles
+    end
+    r1 = m.fc_radius - ag/6
+    x1, y1 = pr2c(r1, alfa)
+    n = math.floor(r1*alfa/agndst + 1.5)
+    nc_circle_m(r1, 0, x1, y1, 0.0, 0.0, n)
 
-if inner_da_start == nil then
-  inner_da_start = da2/2
+    r2 = m.fc_radius + ag/6
+    x2, y2 = pr2c(r2, alfa)
+    nc_circle_m(r2, 0, x2, y2, 0.0, 0.0, n)
+
+    if inner_da_start == nil then
+      inner_da_start = da2/2
+    end
+    nc_line(r1, 0.0, r2, 0.0, 2)
+
+    if outer_da_start == nil then
+      outer_da_start = da1/2
+    end
+    nc_line(r2, 0.0, outer_da_start, 0.0, 0)
+
+    if m.tot_num_slot > m.num_sl_gen then
+      x4, y4 = pr2c(outer_da_start, alfa)
+      nc_line(x1, y1, x2, y2, 2)
+      nc_line(x4, y4, x2, y2, 0)
+    end
+
+    x0, y0 = pr2c(r2-ag/6, alfa/2)
+    create_mesh_se(x0, y0)
+    x0, y0 = pr2c(r2+ag/6, alfa/2)
+    create_mesh_se(x0, y0)
 end
-nc_line(inner_da_start, 0.0, r1, 0.0, 0.0)
-
-if outer_da_start == nil then
-  outer_da_start = da1/2
-end
-nc_line(r2, 0.0, outer_da_start, 0.0, 0.0)
-
-if m.tot_num_slot > m.num_sl_gen then
-  x3, y3 = pr2c(inner_da_end, alfa)
-  x4, y4 = pr2c(outer_da_end, alfa)
-  nc_line(x3, y3, x1, y1, 0, 0)
-  nc_line(x4, y4, x2, y2, 0, 0)
-end
-
-x0, y0 = pr2c(r1-ag/6, alfa/2)
-create_mesh_se(x0, y0)
-x0, y0 = pr2c(r2+ag/6, alfa/2)
-create_mesh_se(x0, y0)


### PR DESCRIPTION
This fixes an issue with mesh-airgap.mako and user defined fsl files for both stator an rotor models. The actual implementation had several flaws:

- variables `agndst` and `alfa` where condsidered `not nil`, which is not always the case
- mixed up radians and degrees in polar to cartesian conversion
- missed creating some nodechains

Also it was not considered if the user had already created the airgap mesh within his fsl-files.
If so, he could now set the variable `airgap_created` to `true`, when he does the creation.

I hope this is useful to other users too. 

Keep up the great work with **femagtools**, they are awesome :)
