### PR TITLE
Set minimum version of netCDF4 (comes with curl) to mitigate CVE-2023-38545

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,12 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-    'numpy', 'scipy', 'mako', 'six', 'lmfit', 'netCDF4'
+    'numpy',
+    'scipy',
+    'mako',
+    'six',
+    'lmfit',
+    'netCDF4>=1.6.5',     # >=1.6.5 to mitigate CVE-2023-38545
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
netCDF4 comes with its own version of libcurl. Previous versions of netCDF4 contained a vulnerable version of libcurl (CVE-2023-38545).
This change makes sure, that users receive a version of libcurl, that is no longer affected.