### PR TITLE
Adds `femagtools[all]` dependency group to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Femagtools is an Open-Source Python-API for FEMAG offering following features:
 * calculate machine characteristics by using analytic machine models
 * execute parameter studies and multi-objective optimization
 
-The package can be used with Python 3.x on Linux, MacOS or Windows and is hosted on github: <https://github.com/SEMAFORInformatik/femagtools/>` where also many examples can be found in the examples directory. Contributions and feedback to this project are highly welcome.
+The package can be used with Python 3.x on Linux, MacOS or Windows and is hosted on github: <https://github.com/SEMAFORInformatik/femagtools/> where also many examples can be found in the examples directory. Contributions and feedback to this project are highly welcome.
 
 The installation can be done in the usual ways with pip:
 
 ```
-pip install femagtools[all]
+pip install 'femagtools[all]'
 ```
-([all] pulls in all optional dependencies.
+`[all]` pulls in all optional dependencies. Up-to-date information about optional dependencies can be found in the [pyproject.toml](pyproject.toml) file under `[project.optional-dependencies]`.
 
 For details see the documentation <http://docs.semafor.ch/femagtools>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,13 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dxfsl = ['dxfgrabber', 'networkx']
-svgfsl = ['dxfgrabber', 'networkx','lxml']
+svgfsl = ['dxfgrabber', 'networkx', 'lxml']
 mplot =  ['matplotlib']
 meshio = ['meshio']
 vtk = ['vtk']
 zmq = ['pyzmq']
 test = ['pytest']
+all = ['femagtools[dxfsl,svgfsl,mplot,meshio,vtk,zmq,test]']    # add new dependency groups here as well
 
 [project.scripts]
 femagtools-plot = "femagtools.plot.bch:main"


### PR DESCRIPTION
The README.md contains information about a `femagtools[all]` installation option, which did not exist. This commit adds it to the pyproject.toml file.