### PR TITLE
Fixes checks for m.remanenc, m.relperm and m.rlen in afm_rotor.mako

### DIFF
--- a/src/femagtools/templates/afm_rotor.mako
+++ b/src/femagtools/templates/afm_rotor.mako
@@ -91,7 +91,11 @@ m.nodedist        = ${model.get('nodedist', 1)}
   x,y = (P22.x+P32.x)/2,(P21.y+P22.y)/2
   if m.remanenc == nil then
     m.remanenc = 1.2
+  end
+  if m.relperm == nil then
     m.relperm = 1.05
+  end
+  if m.rlen == nil then
     m.rlen = 100
   end
   for i = 1,m.npols_gen do


### PR DESCRIPTION
If a previous FSL script set `m.remanenc` but not `m.relperm` and/or `m.rlen` the existing check is not sufficient.